### PR TITLE
Fix for 1.20

### DIFF
--- a/src/data/ps-keep/modules/drop_on_death.bolt
+++ b/src/data/ps-keep/modules/drop_on_death.bolt
@@ -2,7 +2,7 @@
 import requests
 
 blackList = ["compass", "clock", "_sword", "_axe", "_pickaxe", "_hoe", "_shovel", "trident", "bow", "shield",
-    "shears", "flint_and_steal", "_on_a_stick", "spyglass", "fishing_rod", "written_book", "writable_book",
+    "shears", "flint_and_steel", "_on_a_stick", "spyglass", "fishing_rod", "written_book", "writable_book",
     "bucket", "firework_rocket", "arrow", "map", "_boat", "_raft", "minecart", "saddle", "_horse_armor", "golden_apple",
     "totem_of_undying", "potion", "goat_horn", "ender_eye", "ender_pearl", "torch", "_helmet", "_chestplate",
     "_leggings", "_boots", "elytra", "carved_pumpkin", "skeleton_skull", "head"]

--- a/src/data/ps-keep/modules/drop_on_death.bolt
+++ b/src/data/ps-keep/modules/drop_on_death.bolt
@@ -3,11 +3,11 @@ import requests
 
 blackList = ["compass", "clock", "_sword", "_axe", "_pickaxe", "_hoe", "_shovel", "trident", "bow", "shield",
     "shears", "flint_and_steal", "_on_a_stick", "spyglass", "fishing_rod", "written_book", "writable_book",
-    "bucket", "firework_rocket", "arrow", "map", "_boat", "minecart", "saddle", "_horse_armor", "golden_apple",
+    "bucket", "firework_rocket", "arrow", "map", "_boat", "_raft", "minecart", "saddle", "_horse_armor", "golden_apple",
     "totem_of_undying", "potion", "goat_horn", "ender_eye", "ender_pearl", "torch", "_helmet", "_chestplate",
     "_leggings", "_boots", "elytra", "carved_pumpkin", "skeleton_skull", "head"]
 
-url = "https://raw.githubusercontent.com/Arcensoth/mcdata/master/processed/reports/registries/item/data.json"
+url = "https://raw.githubusercontent.com/kittenchilly/mcdata/master/processed/reports/registries/item/data.json"
 response = requests.get(url)
 rawData = response.content
 rawString = rawData.decode()

--- a/src/data/ps-keep/modules/main.bolt
+++ b/src/data/ps-keep/modules/main.bolt
@@ -9,10 +9,14 @@ function ps-keep:load:
     #> Set gamerules and send warnings
     execute store result score #keepInv ps-keep run gamerule keepInventory
     execute if score #keepInv ps-keep matches 0 run tellraw @a ["",{"text":"Keep","color":"#83150D"},{"text":"Some","color":"#248C88"},{"text":"Inventory","color":"#83150D"},{"text":" changed the gamerule "},{"text":"keepInventory","color":"gold"},{"text":" to "},{"text":"true","color":"red"},{"text":"\n \u0020"},{"text":"-> this is necessary for the data pack to work","color":"gray"}]
-    gamerule keepInventory true
+    execute in overworld gamerule keepInventory true
+    execute in nether gamerule keepInventory true
+    execute in the_end gamerule keepInventory true
     execute store result score #respawn ps-keep run gamerule doImmediateRespawn
     execute if score #respawn ps-keep matches 1 run tellraw @a ["",{"text":"Keep","color":"#83150D"},{"text":"Some","color":"#248C88"},{"text":"Inventory","color":"#83150D"},{"text":" changed the gamerule "},{"text":"doImmediateRespawn","color":"gold"},{"text":" to "},{"text":"false","color":"red"},{"text":"\n \u0020"},{"text":"-> this is necessary for the data pack to work","color":"gray"}]
-    gamerule doImmediateRespawn false
+    execute in overworld gamerule doImmediateRespawn false
+    execute in nether gamerule doImmediateRespawn false
+    execute in the_end gamerule doImmediateRespawn false
 
     #> Set up constants
     scoreboard players set .2 ps-keep 2

--- a/src/data/ps-keep/modules/main.bolt
+++ b/src/data/ps-keep/modules/main.bolt
@@ -9,14 +9,14 @@ function ps-keep:load:
     #> Set gamerules and send warnings
     execute store result score #keepInv ps-keep run gamerule keepInventory
     execute if score #keepInv ps-keep matches 0 run tellraw @a ["",{"text":"Keep","color":"#83150D"},{"text":"Some","color":"#248C88"},{"text":"Inventory","color":"#83150D"},{"text":" changed the gamerule "},{"text":"keepInventory","color":"gold"},{"text":" to "},{"text":"true","color":"red"},{"text":"\n \u0020"},{"text":"-> this is necessary for the data pack to work","color":"gray"}]
-    execute in overworld gamerule keepInventory true
-    execute in nether gamerule keepInventory true
-    execute in the_end gamerule keepInventory true
+    execute in overworld run gamerule keepInventory true
+    execute in nether run gamerule keepInventory true
+    execute in the_end run gamerule keepInventory true
     execute store result score #respawn ps-keep run gamerule doImmediateRespawn
     execute if score #respawn ps-keep matches 1 run tellraw @a ["",{"text":"Keep","color":"#83150D"},{"text":"Some","color":"#248C88"},{"text":"Inventory","color":"#83150D"},{"text":" changed the gamerule "},{"text":"doImmediateRespawn","color":"gold"},{"text":" to "},{"text":"false","color":"red"},{"text":"\n \u0020"},{"text":"-> this is necessary for the data pack to work","color":"gray"}]
-    execute in overworld gamerule doImmediateRespawn false
-    execute in nether gamerule doImmediateRespawn false
-    execute in the_end gamerule doImmediateRespawn false
+    execute in overworld run gamerule doImmediateRespawn false
+    execute in nether run gamerule doImmediateRespawn false
+    execute in the_end run gamerule doImmediateRespawn false
 
     #> Set up constants
     scoreboard players set .2 ps-keep 2


### PR DESCRIPTION
mcgen never updated for 1.20, so I made my own fork that has an updated version of it.
Before every new 1.20 block wouldn't drop on death, but it should be fixed with this change.
Also does 2 other things:
- Fixes Flint and Steel typo
- Fixes the datapack not working in the nether or the end while using Bukkit/Spigot/Paper